### PR TITLE
Relax dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in idcf-ilb.gemspec
 gemspec
+
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.2")
+  # activesupport 5+ requires ruby 2.2.2+
+  gem "activesupport", "< 5.0.0"
+end

--- a/idcf-ilb.gemspec
+++ b/idcf-ilb.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"
 
-  spec.add_dependency "activesupport", "~> 4.2.3"
-  spec.add_dependency "faraday", "~> 0.9.1"
-  spec.add_dependency "faraday_middleware", "~> 0.10.0"
+  spec.add_dependency "activesupport", ">= 4.2.3", "< 6"
+  spec.add_dependency "faraday", "~> 0.9"
+  spec.add_dependency "faraday_middleware", "~> 0.10"
 end


### PR DESCRIPTION
I want to use latest gems, but `idcf-ilb` gem is locked by legacy version

# Example
Gemfile

```ruby
source "https://rubygems.org"

gem "idcf-ilb", "0.0.2"
gem "activesupport", "5.0.2"
gem "faraday", "0.11.0"
gem "faraday_middleware", "0.11.0.1"
```

```sh
$ bundle install

(snip)

Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    activesupport (= 5.0.2)

    idcf-ilb (= 0.0.2) was resolved to 0.0.2, which depends on
      activesupport (~> 4.2.3)

Bundler could not find compatible versions for gem "faraday":
  In Gemfile:
    faraday (= 0.11.0)

    faraday_middleware (= 0.11.0.1) was resolved to 0.11.0.1, which depends on
      faraday (< 1.0, >= 0.7.4)

    idcf-ilb was resolved to 0.0.2, which depends on
      faraday (~> 0.9.1)

Bundler could not find compatible versions for gem "faraday_middleware":
  In Gemfile:
    faraday_middleware (= 0.11.0.1)

    idcf-ilb was resolved to 0.0.2, which depends on
      faraday_middleware (~> 0.10.0)
```
