### PR TITLE
Add 'ats_flag' parameter to validatetion of sslcert

### DIFF
--- a/lib/idcf/ilb/validators/base.rb
+++ b/lib/idcf/ilb/validators/base.rb
@@ -48,6 +48,8 @@ module Idcf
               else
                 false
               end
+            when "boolean"
+              value.is_a?(FalseClass) || value.is_a?(TrueClass)
             else
               value.is_a?(valid_type)
             end

--- a/lib/idcf/ilb/validators/sslcert.rb
+++ b/lib/idcf/ilb/validators/sslcert.rb
@@ -16,7 +16,8 @@ module Idcf
           remaining_days:      { type: Integer },
           expired_at:          { type: String },
           created_at:    { type: String },
-          updated_at:    { type: String }
+          updated_at:    { type: String },
+          ats_flag:      { type: "boolean" }
         }
       end
     end

--- a/spec/integration/sslcerts_spec.rb
+++ b/spec/integration/sslcerts_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe Idcf::Ilb::ClientExtensions::Sslcert do
+  include_context "resources"
+
+  describe "#sslcerts" do
+    before { @response = client.sslcerts }
+    context "when valid request" do
+      it do
+        expect(@response).to be_an_instance_of(Array)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I Added because sslcert's validatetion had no definition of 'ats_flag'.