### PR TITLE
[タスク] requestにheader情報がのらない

### DIFF
--- a/lib/idcf/ilb/client_extensions/job.rb
+++ b/lib/idcf/ilb/client_extensions/job.rb
@@ -53,7 +53,7 @@ module Idcf
         # @param headers [Hash] HTTP request headers
         # @return [Array<Resources::Job>] An array of job objects
         def jobs(headers = {})
-          list_jobs(headers).resources.map do |job|
+          list_jobs({}, headers).resources.map do |job|
             Resources::Job.new(self, job)
           end
         end

--- a/lib/idcf/ilb/client_extensions/loadbalancer.rb
+++ b/lib/idcf/ilb/client_extensions/loadbalancer.rb
@@ -69,7 +69,7 @@ module Idcf
         # @param headers [Hash] HTTP request headers
         # @return [Array<Resources::Loadbalancer>] An array of loadbalancer objects
         def loadbalancers(headers = {})
-          list_loadbalancers(headers).resources.map do |loadbalancer|
+          list_loadbalancers({}, headers).resources.map do |loadbalancer|
             Resources::Loadbalancer.new(self, loadbalancer)
           end
         end

--- a/lib/idcf/ilb/client_extensions/log.rb
+++ b/lib/idcf/ilb/client_extensions/log.rb
@@ -20,7 +20,7 @@ module Idcf
         # @param headers [Hash] HTTP request headers
         # @return [Array<Resources::Log>] An array of log objects
         def logs(headers = {})
-          list_logs(headers).resources.map do |log|
+          list_logs({}, headers).resources.map do |log|
             Resources::Log.new(self, log)
           end
         end

--- a/lib/idcf/ilb/client_extensions/sslcert.rb
+++ b/lib/idcf/ilb/client_extensions/sslcert.rb
@@ -69,7 +69,7 @@ module Idcf
         # @param headers [Hash] HTTP request headers
         # @return [Array<Resources::Sslcert>] An array of sslcert objects
         def sslcerts(headers = {})
-          list_sslcerts(headers).resources.map do |sslcert|
+          list_sslcerts({}, headers).resources.map do |sslcert|
             Resources::Sslcert.new(self, sslcert)
           end
         end

--- a/lib/idcf/ilb/client_extensions/virtualmachine.rb
+++ b/lib/idcf/ilb/client_extensions/virtualmachine.rb
@@ -19,7 +19,7 @@ module Idcf
         # @param headers [Hash] HTTP request headers
         # @return [Array<Resources::Virtualmachine>] An array of virtualmachine objects
         def virtualmachines(headers = {})
-          list_virtualmachines(headers).resources.map do |virtualmachine|
+          list_virtualmachines({}, headers).resources.map do |virtualmachine|
             Resources::Virtualmachine.new(self, virtualmachine)
           end
         end


### PR DESCRIPTION
requestにheader情報がのらないバグを修正

対象メソッド
- loadbalancers
- jobs
- logs
- sslcerts
- virtualmachines