### PR TITLE
Feature/add ip reserve

### DIFF
--- a/lib/idcf/ilb/client_extensions/loadbalancer.rb
+++ b/lib/idcf/ilb/client_extensions/loadbalancer.rb
@@ -8,6 +8,7 @@ module Idcf
         # @param attributes [Hash] request attributes
         # @option attributes [String] :name unique name of loadbalancer (required)
         # @option attributes [String] :network_id network_id of active network (required)
+        # @option attributes [TrueClass] :public_ipaddress_assignment (optional)
         # @option attributes [Array] :configs configs of loadbalancer (required)
         # @option attributes [Hash] :mackerel mackerel (optional)
         # @option attributes [String] :fwgroup_id (optional)
@@ -26,6 +27,7 @@ module Idcf
         # @option attributes [String] :certificate of loadbalancer (required)
         # @option attributes [String] :private_key of loadbalancer (required)
         # @option attributes [String] :certificate_chain of loadbalancer (optional)
+        # @option attributes [TrueClass] :public_ipaddress_assignment (optional)
         # @param headers [Hash] HTTP request headers
         # @return [Response] HTTP response object
         def update_loadbalancer(id, attributes, headers = {})

--- a/lib/idcf/ilb/client_extensions/loadbalancer.rb
+++ b/lib/idcf/ilb/client_extensions/loadbalancer.rb
@@ -8,7 +8,7 @@ module Idcf
         # @param attributes [Hash] request attributes
         # @option attributes [String] :name unique name of loadbalancer (required)
         # @option attributes [String] :network_id network_id of active network (required)
-        # @option attributes [TrueClass] :public_ipaddress_assignment (optional)
+        # @option attributes [Object(true)] :public_ipaddress_assignment (optional)
         # @option attributes [Array] :configs configs of loadbalancer (required)
         # @option attributes [Hash] :mackerel mackerel (optional)
         # @option attributes [String] :fwgroup_id (optional)
@@ -27,7 +27,7 @@ module Idcf
         # @option attributes [String] :certificate of loadbalancer (required)
         # @option attributes [String] :private_key of loadbalancer (required)
         # @option attributes [String] :certificate_chain of loadbalancer (optional)
-        # @option attributes [TrueClass] :public_ipaddress_assignment (optional)
+        # @option attributes [Object(true)] :public_ipaddress_assignment (optional)
         # @param headers [Hash] HTTP request headers
         # @return [Response] HTTP response object
         def update_loadbalancer(id, attributes, headers = {})

--- a/lib/idcf/ilb/resources/base.rb
+++ b/lib/idcf/ilb/resources/base.rb
@@ -49,7 +49,6 @@ module Idcf
         private
 
         def attributes=(attributes)
-          self.class.validator_class.validate_attributes!(attributes)
           attributes.each do |name, value|
             instance_variable_set(:"@#{name}", value)
           end

--- a/lib/idcf/ilb/validators/loadbalancer.rb
+++ b/lib/idcf/ilb/validators/loadbalancer.rb
@@ -4,23 +4,23 @@ module Idcf
       # Loadbalancer validator class
       class Loadbalancer < Base
         self.valid_attributes = {
-          id:                       { type: String },
-          account_id:               { type: String },
-          name:                     { type: String, create: :required },
-          network_id:               { type: String, create: :required },
-          network_name:             { type: String },
-          network:                  { type: Hash },
-          configs:                  { type: Array, create: :required, update: :required },
-          mackerel:                 { type: Hash, create: :optional, update: :optional },
-          global_ipaddress_reserve: { type: boolean, create: :optional, update: :optional },
-          fqdn:                     { type: String },
-          state:                    { type: String },
-          zone_id:                  { type: String },
-          zone_name:                { type: String },
-          fwgroup_id:               { type: String, create: :optional, update: :optional },
-          created_at:               { type: String },
-          updated_at:               { type: String },
-          redirects:                { type: Array, create: :optional, update: :optional }
+          id:                          { type: String },
+          account_id:                  { type: String },
+          name:                        { type: String, create: :required },
+          network_id:                  { type: String, create: :required },
+          network_name:                { type: String },
+          network:                     { type: Hash },
+          configs:                     { type: Array, create: :required, update: :required },
+          mackerel:                    { type: Hash, create: :optional, update: :optional },
+          public_ipaddress_assignment: { type: TrueClass, create: :optional, update: :optional },
+          fqdn:                        { type: String },
+          state:                       { type: String },
+          zone_id:                     { type: String },
+          zone_name:                   { type: String },
+          fwgroup_id:                  { type: String, create: :optional, update: :optional },
+          created_at:                  { type: String },
+          updated_at:                  { type: String },
+          redirects:                   { type: Array, create: :optional, update: :optional }
         }
       end
     end

--- a/lib/idcf/ilb/validators/loadbalancer.rb
+++ b/lib/idcf/ilb/validators/loadbalancer.rb
@@ -4,22 +4,23 @@ module Idcf
       # Loadbalancer validator class
       class Loadbalancer < Base
         self.valid_attributes = {
-          id:                  { type: String },
-          account_id:          { type: String },
-          name:                { type: String, create: :required },
-          network_id:          { type: String, create: :required },
-          network_name:        { type: String },
-          network:             { type: Hash },
-          configs:             { type: Array, create: :required, update: :required },
-          mackerel:            { type: Hash, create: :optional, update: :optional },
-          fqdn:                { type: String },
-          state:               { type: String },
-          zone_id:             { type: String },
-          zone_name:           { type: String },
-          fwgroup_id:          { type: String, create: :optional, update: :optional },
-          created_at:          { type: String },
-          updated_at:          { type: String },
-          redirects:           { type: Array, create: :optional, update: :optional }
+          id:                       { type: String },
+          account_id:               { type: String },
+          name:                     { type: String, create: :required },
+          network_id:               { type: String, create: :required },
+          network_name:             { type: String },
+          network:                  { type: Hash },
+          configs:                  { type: Array, create: :required, update: :required },
+          mackerel:                 { type: Hash, create: :optional, update: :optional },
+          global_ipaddress_reserve: { type: boolean, create: :optional, update: :optional },
+          fqdn:                     { type: String },
+          state:                    { type: String },
+          zone_id:                  { type: String },
+          zone_name:                { type: String },
+          fwgroup_id:               { type: String, create: :optional, update: :optional },
+          created_at:               { type: String },
+          updated_at:               { type: String },
+          redirects:                { type: Array, create: :optional, update: :optional }
         }
       end
     end

--- a/lib/idcf/ilb/validators/loadbalancer.rb
+++ b/lib/idcf/ilb/validators/loadbalancer.rb
@@ -12,7 +12,7 @@ module Idcf
           network:                     { type: Hash },
           configs:                     { type: Array, create: :required, update: :required },
           mackerel:                    { type: Hash, create: :optional, update: :optional },
-          public_ipaddress_assignment: { type: TrueClass, create: :optional, update: :optional },
+          public_ipaddress_assignment: { type: Object, create: :optional, update: :optional },
           fqdn:                        { type: String },
           state:                       { type: String },
           zone_id:                     { type: String },

--- a/lib/idcf/ilb/validators/loadbalancer.rb
+++ b/lib/idcf/ilb/validators/loadbalancer.rb
@@ -12,7 +12,7 @@ module Idcf
           network:                     { type: Hash },
           configs:                     { type: Array, create: :required, update: :required },
           mackerel:                    { type: Hash, create: :optional, update: :optional },
-          public_ipaddress_assignment: { type: Object, create: :optional, update: :optional },
+          public_ipaddress_assignment: { type: TrueClass, create: :optional, update: :optional },
           fqdn:                        { type: String },
           state:                       { type: String },
           zone_id:                     { type: String },

--- a/lib/idcf/ilb/version.rb
+++ b/lib/idcf/ilb/version.rb
@@ -1,5 +1,5 @@
 module Idcf
   module Ilb
-    VERSION = "0.0.5".freeze
+    VERSION = "0.0.6".freeze
   end
 end


### PR DESCRIPTION
# 変更

Public IP Address Assignment の設定がidcf-ilb-ruby経由でもできるよう追加しました

# mergeできるタイミング

- [ ] IP固定化を使った作成がidcf-ilb-ruby経由でできる
- [ ] IP固定化を使った更新がidcf-ilb-ruby経由でできる