### PR TITLE
add auto scale planning

### DIFF
--- a/lib/idcf/ilb/client_extensions/loadbalancer.rb
+++ b/lib/idcf/ilb/client_extensions/loadbalancer.rb
@@ -9,6 +9,7 @@ module Idcf
         # @option attributes [String] :name unique name of loadbalancer (required)
         # @option attributes [String] :network_id network_id of active network (required)
         # @option attributes [Object(true)] :public_ipaddress_assignment (optional)
+        # @option attributes [Hash] :auto_scale_planning (optional)
         # @option attributes [Array] :configs configs of loadbalancer (required)
         # @option attributes [Hash] :mackerel mackerel (optional)
         # @option attributes [String] :fwgroup_id (optional)
@@ -28,6 +29,7 @@ module Idcf
         # @option attributes [String] :private_key of loadbalancer (required)
         # @option attributes [String] :certificate_chain of loadbalancer (optional)
         # @option attributes [Object(true)] :public_ipaddress_assignment (optional)
+        # @option attributes [Hash] :auto_scale_planning (optional)
         # @param headers [Hash] HTTP request headers
         # @return [Response] HTTP response object
         def update_loadbalancer(id, attributes, headers = {})

--- a/lib/idcf/ilb/validators/loadbalancer.rb
+++ b/lib/idcf/ilb/validators/loadbalancer.rb
@@ -13,6 +13,7 @@ module Idcf
           configs:                     { type: Array, create: :required, update: :required },
           mackerel:                    { type: Hash, create: :optional, update: :optional },
           public_ipaddress_assignment: { type: TrueClass, create: :optional, update: :optional },
+          auto_scale_planning:         { type: Hash, create: :optional, update: :optional },
           fqdn:                        { type: String },
           state:                       { type: String },
           zone_id:                     { type: String },


### PR DESCRIPTION
## 変更点

下記APIでauto_scale_planningのパラメータを受け付けるよう変更した

- create_loadbalancer
- update_loadbalancer

### パラメータサンプル

```
auto_scale_planning: { min: 3, max: 5}
```

## mergeできるタイミング
- [x] クライアント経由で、`auto_scale_planning` を含んだloadbalancerの作成が成功すること
- [x] クライアント経由で、`auto_scale_planning` を含んだloadbalancerの更新が成功すること
- [x] クライアント経由で、`auto_scale_planning` を不正な値にしたloadbalancerの作成・更新が失敗すること